### PR TITLE
feat: Add support for local environment settings

### DIFF
--- a/stack
+++ b/stack
@@ -1,15 +1,20 @@
 #!/usr/bin/env sh
 STACK_PATH=$(pwd)
+PROJECT_PATH=$(pwd)
 
 set -ae
 
-source "$STACK_PATH/.env.dist"
-if [ -f "$STACK_PATH/.env" ]; then
-    source "$STACK_PATH/.env"
+. "${STACK_PATH}/.env.dist" # default settings
+if [ -f "${STACK_PATH}/.env" ]; then
+    . "${STACK_PATH}/.env" # custom *global* settings
+elif [ -f "${PROJECT_PATH}/.env" ]; then
+    . "${PROJECT_PATH}/.env" # custom *local* settings
 fi
 
-if [ "path" = $1 ]; then
-    echo $STACK_PATH
+if [ "path" = "${1}" ]; then
+    echo "Stack path: ${STACK_PATH}"
+    echo "Project path: ${PROJECT_PATH}"
+
     exit
 fi
 


### PR DESCRIPTION
This PR changes the way settings are loaded early on the script.

1. It loads the default `.env.dist` settings file from stack's path (**unchanged**);
2. It checks for a `.env` settings file in stack's path and loads it if found (**unchanged**);
3. It checks for a `.env` settings file in project's path and loads it if found (**new**).

Note that the project's `.env` settings file will override stack's `.env.dist`/`.env` settings if and only if it sets the _same_ env variables used by the stack (eg. `KAFKA_PORT`), keeping previous behavior untouched.

This PR also replaces `source` with `.` to include settings files to keep it POSIX compliant (https://www.shellcheck.net/wiki/SC3051), as it is executed by `sh` and not by `bash`.