### PR TITLE
fix: `stack` helper execution

### DIFF
--- a/stack
+++ b/stack
@@ -1,4 +1,4 @@
-#!/usr/bin/env sh
+#!/usr/bin/env bash
 STACK_PATH=$(pwd)
 PROJECT_PATH=$(pwd)
 
@@ -99,5 +99,5 @@ if [ ! -f "${COMPONENT}/docker-compose.yml" ]; then
     exit 1
 fi
 
-CMD=${@:2}
+CMD="${@:2}"
 $CONTAINER_COMPOSE -f "${COMPONENT}/docker-compose.yml" ${CMD:-up -d}


### PR DESCRIPTION
**Problem:** `stack <component>` command resulting in `/usr/local/bin/stack: 102: Bad substitution`.
**OS details:** Ubuntu 22.04.2 LTS

Searching about the error, I found it is related to [shell interpreter](https://github.com/opencodeco/stack/blob/9bf9dfaa925d311a070c80a5b49e6fc4e12f31ed/stack#L1) when trying to get the command line arguments here:
https://github.com/opencodeco/stack/blob/9bf9dfaa925d311a070c80a5b49e6fc4e12f31ed/stack#L102

I'm proposing these changes based on the other OpenCodeCo project: `phpctl`. `phpctl` have a shell script to execute project commands which has a similar [arguments slicing](https://github.com/opencodeco/phpctl/blob/a43b644add1959279e61e3867bac2aaa69a53657/bin/phpctl#L19), having a different [hashbang line](https://github.com/opencodeco/phpctl/blob/a43b644add1959279e61e3867bac2aaa69a53657/bin/phpctl#L1).

After the changes, everything worked as expected and I was able to execute `stack mysql` without errors.