### PR TITLE
fix: RabbitMQ component

### DIFF
--- a/rabbitmq/docker-compose.yml
+++ b/rabbitmq/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3'
+services:
+  opencodeco-rabbitmq:
+    container_name: opencodeco-rabbitmq
+    image: rabbitmq:3-management-alpine
+    ports:
+      - ${RABBITMQ_PORT}:5672
+      - ${RABBITMQ_UI_PORT}:15672
+    environment:
+      RABBITMQ_DEFAULT_USER: opencodeco
+      RABBITMQ_DEFAULT_PASS: opencodeco
+    volumes:
+      - opencodeco-rabbitmq:/var/lib/rabbitmq
+      
+networks:
+  default:
+    name: opencodeco
+    external: true
+      
+volumes:
+  opencodeco-rabbitmq:
+    name: opencodeco-rabbitmq


### PR DESCRIPTION
**Problem:** _Whoops! Component "/path/to/stack/rabbitmq" does not exists._

RabbitMQ has been declared in README file, but its component is missing from the project.
https://github.com/opencodeco/stack/blob/1ad8f6f6c8f520aef26b884a047b03d640e908dd/README.md?plain=1#L13

# Screenshots

### Login
![image](https://github.com/opencodeco/stack/assets/12822075/68d51e67-9f07-49d8-b7fe-c26075b8dff8)

### Dashboard
![image](https://github.com/opencodeco/stack/assets/12822075/1313b339-df80-4779-baa5-55868ac4c239)

### Queue
![image](https://github.com/opencodeco/stack/assets/12822075/8230547e-3529-41f6-b793-5e5da5750e20)

### Queue message
![image](https://github.com/opencodeco/stack/assets/12822075/7ad0b115-d6dd-44b0-a20e-39d4120d193d)
