### PR TITLE
feat: add support fo docker compose running as docker plugin

### DIFF
--- a/stack
+++ b/stack
@@ -59,8 +59,10 @@ if command -v docker-compose > /dev/null 2>&1; then
     CONTAINER_COMPOSE=docker-compose
 elif command -v podman-compose > /dev/null 2>&1; then
     CONTAINER_COMPOSE=podman-compose
+elif docker compose --help > /dev/null 2>&1; then
+    CONTAINER_COMPOSE="docker compose"
 else
-    echo "Could not find neither \"docker-compose\" nor \"podman-compose\", aborting"
+    echo "Could not find \"docker-compose\", \"podman-compose\" or \"docker compose\", aborting"
     exit 1
 fi
 


### PR DESCRIPTION
Add support for the [current](https://docs.docker.com/compose/releases/migrate/#what-are-the-differences-between-compose-v1-and-compose-v2) docker compose tool.