### PR TITLE
fix: o11y bind OTel Collector to 0.0.0.0 for cross-container access

### DIFF
--- a/o11y/otelcol-config.yml
+++ b/o11y/otelcol-config.yml
@@ -5,7 +5,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 
 exporters:
   debug:


### PR DESCRIPTION
Since otel/opentelemetry-collector-contrib v0.111.0, the default endpoint changed from 0.0.0.0 to localhost, breaking connectivity from other containers in the docker network.